### PR TITLE
fix return line

### DIFF
--- a/h264/sps.go
+++ b/h264/sps.go
@@ -538,8 +538,8 @@ func NewSPS(rbsp []byte, showPacket bool) (*SPS, error) {
 
 			sps.MaxBitsPerMbDenom, err = readUe(nil)
 			if err != nil {
+				return nil, errors.Wrap(err, "could not parse MaxBitsPerMbDenom")
 			}
-			return nil, errors.Wrap(err, "could not parse MaxBitsPerMbDenom")
 
 			sps.Log2MaxMvLengthHorizontal, err = readUe(nil)
 			if err != nil {


### PR DESCRIPTION
Fix a return statement that appears to have been accidentally pulled out of an error check. The code after the original return was all unreachable.