### PR TITLE
h264: using int const for chroma format

### DIFF
--- a/h264/cabac.go
+++ b/h264/cabac.go
@@ -30,14 +30,14 @@ func YOffset(yRefMin16, refMbH int) int {
 }
 func MbWidthC(sps *SPS) int {
 	mbWidthC := 16 / SubWidthC(sps)
-	if sps.ChromaFormat == 0 || sps.UseSeparateColorPlane {
+	if sps.ChromaFormat == chromaMonochrome || sps.UseSeparateColorPlane {
 		mbWidthC = 0
 	}
 	return mbWidthC
 }
 func MbHeightC(sps *SPS) int {
 	mbHeightC := 16 / SubHeightC(sps)
-	if sps.ChromaFormat == 0 || sps.UseSeparateColorPlane {
+	if sps.ChromaFormat == chromaMonochrome || sps.UseSeparateColorPlane {
 		mbHeightC = 0
 	}
 	return mbHeightC

--- a/h264/pps.go
+++ b/h264/pps.go
@@ -156,7 +156,7 @@ func NewPPS(sps *SPS, rbsp []byte, showPacket bool) (*PPS, error) {
 		pps.PicScalingMatrixPresent = flagField()
 		if pps.PicScalingMatrixPresent {
 			v := 6
-			if sps.ChromaFormat != 3 {
+			if sps.ChromaFormat != chroma444 {
 				v = 2
 			}
 			for i := 0; i < 6+(v*pps.Transform8x8Mode); i++ {

--- a/h264/slice.go
+++ b/h264/slice.go
@@ -7,6 +7,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Chroma formats as defined in section 6.2, tab 6-1.
+const (
+	chromaMonochrome = iota
+	chroma420
+	chroma422
+	chroma444
+)
+
 type VideoStream struct {
 	SPS    *SPS
 	PPS    *PPS
@@ -181,19 +189,19 @@ func PicSizeInMbs(sps *SPS, header *SliceHeader) int {
 func SubWidthC(sps *SPS) int {
 	n := 17
 	if sps.UseSeparateColorPlane {
-		if sps.ChromaFormat == 3 {
+		if sps.ChromaFormat == chroma444 {
 			return n
 		}
 	}
 
 	switch sps.ChromaFormat {
-	case 0:
+	case chromaMonochrome:
 		return n
-	case 1:
+	case chroma420:
 		n = 2
-	case 2:
+	case chroma422:
 		n = 2
-	case 3:
+	case chroma444:
 		n = 1
 
 	}
@@ -202,18 +210,18 @@ func SubWidthC(sps *SPS) int {
 func SubHeightC(sps *SPS) int {
 	n := 17
 	if sps.UseSeparateColorPlane {
-		if sps.ChromaFormat == 3 {
+		if sps.ChromaFormat == chroma444 {
 			return n
 		}
 	}
 	switch sps.ChromaFormat {
-	case 0:
+	case chromaMonochrome:
 		return n
-	case 1:
+	case chroma420:
 		n = 2
-	case 2:
+	case chroma422:
 		n = 1
-	case 3:
+	case chroma444:
 		n = 1
 
 	}
@@ -724,7 +732,7 @@ func NewSliceData(sliceContext *SliceContext, b *BitReader) (*SliceData, error) 
 				mbWidthC := 16 / SubWidthC(sliceContext.SPS)
 				mbHeightC := 16 / SubHeightC(sliceContext.SPS)
 				// if monochrome
-				if sliceContext.SPS.ChromaFormat == 0 || sliceContext.SPS.UseSeparateColorPlane {
+				if sliceContext.SPS.ChromaFormat == chromaMonochrome || sliceContext.SPS.UseSeparateColorPlane {
 					mbWidthC = 0
 					mbHeightC = 0
 				}

--- a/h264/sps.go
+++ b/h264/sps.go
@@ -263,7 +263,7 @@ func NewSPS(rbsp []byte, showPacket bool) (*SPS, error) {
 	isProfileIDC := []int{100, 110, 122, 244, 44, 83, 86, 118, 128, 138, 139, 134, 135}
 	// SpecialProfileCase1
 	if isInList(isProfileIDC, sps.Profile) {
-		if sps.ChromaFormat == 3 {
+		if sps.ChromaFormat == chroma444 {
 			if v := b.NextField("SeperateColorPlaneFlag", 1); v == 1 {
 				sps.UseSeparateColorPlane = true
 			} else {
@@ -293,7 +293,7 @@ func NewSPS(rbsp []byte, showPacket bool) (*SPS, error) {
 		}
 		if sps.SeqScalingMatrixPresent {
 			max := 12
-			if sps.ChromaFormat != 3 {
+			if sps.ChromaFormat != chroma444 {
 				max = 8
 			}
 			logger.Printf("debug: \tbuilding Scaling matrix for %d elements\n", max)


### PR DESCRIPTION
Fixes #18 

Using int consts for different chroma formats. 