### PR TITLE
h264/pps.go: Handle readUe error

### DIFF
--- a/h264/pps.go
+++ b/h264/pps.go
@@ -87,7 +87,10 @@ func NewPPS(sps *SPS, rbsp []byte, showPacket bool) (*PPS, error) {
 			}
 		} else if pps.SliceGroupMapType == 2 {
 			for iGroup := 0; iGroup < pps.NumSliceGroupsMinus1; iGroup++ {
-				pps.TopLeft[iGroup], _ = readUe(nil)
+				pps.TopLeft[iGroup], err = readUe(nil)
+				if err != nil {
+					return nil, errors.Wrap(err, "could not parse TopLeft[iGroup]")
+				}
 				if err != nil {
 					return nil, errors.Wrap(err, "could not parse TopLeft[iGroup]")
 				}


### PR DESCRIPTION
Resolves #15 
Handling error from readUe call on line 90, pps.go.