### PR TITLE
h264: using consts in MbPartPredMode function

### DIFF
--- a/h264/mbType.go
+++ b/h264/mbType.go
@@ -89,6 +89,7 @@ func MbTypeName(sliceType string, mbType int) string {
 	return sliceTypeName
 }
 
+// Errors used by MbPartPredMode.
 var (
 	errNaMode    = errors.New("no mode for given slice and mb type")
 	errPartition = errors.New("partition must be 0")

--- a/h264/parse.go
+++ b/h264/parse.go
@@ -20,11 +20,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-type macroblockPredictionMode uint8
+type mbPartPredMode int8
 
 const (
-	intra4x4 macroblockPredictionMode = iota
+	intra4x4 mbPartPredMode = iota
 	intra8x8
+	intra16x16
+	predL0
+	predL1
+	direct
+	biPred
 	inter
 )
 
@@ -90,7 +95,7 @@ func readSe(r bitio.Reader) (int, error) {
 // readMe parses a syntax element of me(v) descriptor, i.e. mapped
 // Exp-Golomb-coded element, using methods described in sections 9.1 and 9.1.2
 // in Rec. ITU-T H.264 (04/2017).
-func readMe(r bitio.Reader, chromaArrayType uint, mpm macroblockPredictionMode) (uint, error) {
+func readMe(r bitio.Reader, chromaArrayType uint, mpm mbPartPredMode) (uint, error) {
 	// Indexes to codedBlockPattern map.
 	var i1, i2, i3 int
 

--- a/h264/parse_test.go
+++ b/h264/parse_test.go
@@ -120,7 +120,7 @@ func TestReadMe(t *testing.T) {
 	tests := []struct {
 		in   []byte // Input data.
 		cat  uint   // Chroma array..
-		mpm  macroblockPredictionMode
+		mpm  mbPartPredMode
 		want uint  // Expected result from readMe.
 		err  error // Expected value of err from readMe.
 	}{


### PR DESCRIPTION
Resolves #14
Replacing usage of strings to represent macroblock partition prediction modes with int8 consts. Also made changes to affected code. 